### PR TITLE
Fix search audit implementation issue

### DIFF
--- a/src/agentic_search_audit/extractors/results.py
+++ b/src/agentic_search_audit/extractors/results.py
@@ -81,7 +81,7 @@ class ResultsExtractor:
                 if count > 0:
                     logger.info(f"Found {count} items with selector: {selector}")
                     # Return list of nth-child selectors
-                    return [f"{selector}:nth-of-type({i+1})" for i in range(count)]
+                    return [f"{selector}:nth-of-type({i + 1})" for i in range(count)]
             except Exception as e:
                 logger.debug(f"Selector {selector} failed: {e}")
                 continue

--- a/src/agentic_search_audit/mcp/client.py
+++ b/src/agentic_search_audit/mcp/client.py
@@ -164,10 +164,10 @@ class MCPBrowserClient:
             result = await self._call_tool(
                 "evaluate_script",
                 {
-                    "function": f"""(selector) => {{
+                    "function": """(selector) => {
                         const el = document.querySelector(selector);
-                        return el ? {{exists: true}} : null;
-                    }}""",
+                        return el ? {exists: true} : null;
+                    }""",
                     "args": [selector],
                 },
             )
@@ -189,10 +189,10 @@ class MCPBrowserClient:
             result = await self._call_tool(
                 "evaluate_script",
                 {
-                    "function": f"""(selector) => {{
+                    "function": """(selector) => {
                         const elements = document.querySelectorAll(selector);
-                        return Array.from(elements).map((el, i) => ({{index: i}}));
-                    }}""",
+                        return Array.from(elements).map((el, i) => ({index: i}));
+                    }""",
                     "args": [selector],
                 },
             )

--- a/src/agentic_search_audit/mcp/client.py
+++ b/src/agentic_search_audit/mcp/client.py
@@ -1,7 +1,7 @@
 """MCP client for browser automation via chrome-devtools-mcp."""
 
 import asyncio
-import base64
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -108,7 +108,7 @@ class MCPBrowserClient:
 
         Args:
             url: URL to navigate to
-            wait_until: Wait condition (load, domcontentloaded, networkidle)
+            wait_until: Wait condition (load, domcontentloaded, networkidle) - Note: ignored for chrome-devtools-mcp
 
         Returns:
             Final URL after navigation
@@ -118,15 +118,15 @@ class MCPBrowserClient:
         # Initialize page if not done yet
         if not self._page_initialized:
             await self._call_tool(
-                "puppeteer_navigate",
+                "navigate_page",
                 {
                     "url": url,
-                    "waitUntil": wait_until,
+                    "type": "url",
                 },
             )
             # Set viewport
             await self._call_tool(
-                "puppeteer_set_viewport",
+                "resize_page",
                 {
                     "width": self.viewport_width,
                     "height": self.viewport_height,
@@ -135,17 +135,21 @@ class MCPBrowserClient:
             self._page_initialized = True
         else:
             await self._call_tool(
-                "puppeteer_navigate",
+                "navigate_page",
                 {
                     "url": url,
-                    "waitUntil": wait_until,
+                    "type": "url",
                 },
             )
 
-        # Get current URL
-        current_url = await self._call_tool("puppeteer_url", {})
+        # Get current URL using evaluate_script
+        result = await self._call_tool(
+            "evaluate_script",
+            {"function": "() => { return window.location.href; }"},
+        )
+        current_url = result[0].text if result else url
         logger.info(f"Navigated to {current_url}")
-        return current_url[0].text if current_url else url
+        return current_url
 
     async def query_selector(self, selector: str) -> dict[str, Any] | None:
         """Query DOM for a single element.
@@ -158,10 +162,16 @@ class MCPBrowserClient:
         """
         try:
             result = await self._call_tool(
-                "puppeteer_query_selector",
-                {"selector": selector},
+                "evaluate_script",
+                {
+                    "function": f"""(selector) => {{
+                        const el = document.querySelector(selector);
+                        return el ? {{exists: true}} : null;
+                    }}""",
+                    "args": [selector],
+                },
             )
-            return result[0].text if result else None
+            return {"exists": True} if result and result[0].text != "null" else None
         except Exception as e:
             logger.debug(f"Selector {selector} not found: {e}")
             return None
@@ -177,10 +187,19 @@ class MCPBrowserClient:
         """
         try:
             result = await self._call_tool(
-                "puppeteer_query_selector_all",
-                {"selector": selector},
+                "evaluate_script",
+                {
+                    "function": f"""(selector) => {{
+                        const elements = document.querySelectorAll(selector);
+                        return Array.from(elements).map((el, i) => ({{index: i}}));
+                    }}""",
+                    "args": [selector],
+                },
             )
-            return result if result else []
+            if result and result[0].text:
+                elements = json.loads(result[0].text)
+                return elements if isinstance(elements, list) else []
+            return []
         except Exception as e:
             logger.debug(f"Selector {selector} returned no results: {e}")
             return []
@@ -195,8 +214,8 @@ class MCPBrowserClient:
             Result of evaluation
         """
         result = await self._call_tool(
-            "puppeteer_evaluate",
-            {"script": expression},
+            "evaluate_script",
+            {"function": f"() => {{ return {expression}; }}"},
         )
         return result[0].text if result else None
 
@@ -208,8 +227,18 @@ class MCPBrowserClient:
         """
         logger.debug(f"Clicking {selector}")
         await self._call_tool(
-            "puppeteer_click",
-            {"selector": selector},
+            "evaluate_script",
+            {
+                "function": """(selector) => {
+                    const el = document.querySelector(selector);
+                    if (el) {
+                        el.click();
+                        return true;
+                    }
+                    return false;
+                }""",
+                "args": [selector],
+            },
         )
 
     async def type_text(self, selector: str, text: str, delay: int = 50) -> None:
@@ -218,20 +247,27 @@ class MCPBrowserClient:
         Args:
             selector: CSS selector for input element
             text: Text to type
-            delay: Delay between keystrokes in ms
+            delay: Delay between keystrokes in ms (Note: delay not supported in current implementation)
         """
         logger.debug(f"Typing '{text}' into {selector}")
-        # Focus first
+        # Use evaluate_script to set the value and trigger input events
         await self._call_tool(
-            "puppeteer_click",
-            {"selector": selector},
-        )
-        await asyncio.sleep(0.1)
-
-        # Type text
-        await self._call_tool(
-            "puppeteer_type",
-            {"selector": selector, "text": text, "delay": delay},
+            "evaluate_script",
+            {
+                "function": """(selector, text) => {
+                    const el = document.querySelector(selector);
+                    if (el) {
+                        el.focus();
+                        el.value = text;
+                        // Trigger input event to notify any listeners
+                        el.dispatchEvent(new Event('input', { bubbles: true }));
+                        el.dispatchEvent(new Event('change', { bubbles: true }));
+                        return true;
+                    }
+                    return false;
+                }""",
+                "args": [selector, text],
+            },
         )
 
     async def press_key(self, key: str) -> None:
@@ -242,7 +278,7 @@ class MCPBrowserClient:
         """
         logger.debug(f"Pressing key: {key}")
         await self._call_tool(
-            "puppeteer_keyboard_press",
+            "press_key",
             {"key": key},
         )
 
@@ -258,20 +294,17 @@ class MCPBrowserClient:
         """
         logger.debug(f"Taking screenshot: {output_path}")
 
-        result = await self._call_tool(
-            "puppeteer_screenshot",
+        # Ensure parent directory exists
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        await self._call_tool(
+            "take_screenshot",
             {
-                "path": str(output_path),
+                "filePath": str(output_path),
                 "fullPage": full_page,
+                "format": "png",
             },
         )
-
-        # Handle base64 encoded image if returned
-        if result and len(result) > 0 and hasattr(result[0], "text"):
-            # If image data is returned, save it
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_path, "wb") as f:
-                f.write(base64.b64decode(result[0].text))
 
         logger.info(f"Screenshot saved to {output_path}")
         return output_path
@@ -282,7 +315,10 @@ class MCPBrowserClient:
         Returns:
             Full page HTML
         """
-        result = await self._call_tool("puppeteer_html", {})
+        result = await self._call_tool(
+            "evaluate_script",
+            {"function": "() => { return document.documentElement.outerHTML; }"},
+        )
         return result[0].text if result else ""
 
     async def wait_for_selector(
@@ -299,29 +335,53 @@ class MCPBrowserClient:
             True if found, False if timeout
         """
         try:
-            await self._call_tool(
-                "puppeteer_wait_for_selector",
-                {
-                    "selector": selector,
-                    "timeout": timeout,
-                    "visible": visible,
-                },
-            )
-            return True
+            # Poll for element using evaluate_script
+            start_time = asyncio.get_event_loop().time()
+            timeout_seconds = timeout / 1000.0
+            poll_interval = 0.1  # 100ms
+
+            while True:
+                result = await self._call_tool(
+                    "evaluate_script",
+                    {
+                        "function": """(selector, checkVisible) => {
+                            const el = document.querySelector(selector);
+                            if (!el) return false;
+                            if (checkVisible) {
+                                const style = window.getComputedStyle(el);
+                                return style.display !== 'none' && style.visibility !== 'hidden';
+                            }
+                            return true;
+                        }""",
+                        "args": [selector, visible],
+                    },
+                )
+
+                if result and result[0].text == "true":
+                    return True
+
+                # Check timeout
+                elapsed = asyncio.get_event_loop().time() - start_time
+                if elapsed >= timeout_seconds:
+                    logger.debug(f"Timeout waiting for {selector}")
+                    return False
+
+                # Wait before polling again
+                await asyncio.sleep(poll_interval)
+
         except Exception as e:
-            logger.debug(f"Timeout waiting for {selector}: {e}")
+            logger.debug(f"Error waiting for {selector}: {e}")
             return False
 
     async def wait_for_network_idle(self, timeout: int = 2000) -> None:
         """Wait for network to be idle.
 
         Args:
-            timeout: Timeout in milliseconds
+            timeout: Timeout in milliseconds (Note: simplified implementation with fixed wait)
         """
-        await self._call_tool(
-            "puppeteer_wait_for_network_idle",
-            {"timeout": timeout},
-        )
+        # chrome-devtools-mcp doesn't have a direct network idle wait
+        # Use a simple wait as a temporary solution
+        await asyncio.sleep(timeout / 1000.0)
 
     async def get_element_text(self, selector: str) -> str | None:
         """Get text content of an element.

--- a/src/agentic_search_audit/report/generator.py
+++ b/src/agentic_search_audit/report/generator.py
@@ -286,7 +286,7 @@ class ReportGenerator:
     <div class="header">
         <h1>Search Quality Audit Report</h1>
         <p><strong>Site:</strong> {self.config.site.url}</p>
-        <p><strong>Date:</strong> {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</p>
+        <p><strong>Date:</strong> {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}</p>
         <p><strong>Total Queries:</strong> {len(records)}</p>
     </div>
 """


### PR DESCRIPTION
Updated the MCP browser client to use the correct tool names from chrome-devtools-mcp instead of puppeteer-style tool names:

- navigate_page instead of puppeteer_navigate
- resize_page instead of puppeteer_set_viewport
- evaluate_script instead of puppeteer_evaluate/puppeteer_url/puppeteer_html
- press_key instead of puppeteer_keyboard_press
- take_screenshot instead of puppeteer_screenshot

Also implemented workarounds for tools that don't have direct equivalents:
- query_selector/query_selector_all now use evaluate_script
- click and type_text now use evaluate_script with DOM manipulation
- wait_for_selector now uses polling with evaluate_script
- wait_for_network_idle now uses simple sleep (temporary solution)

This fixes the "Tool puppeteer_navigate not found" error.