### PR TITLE
Fix agentic search audit test issue

### DIFF
--- a/src/agentic_search_audit/mcp/client.py
+++ b/src/agentic_search_audit/mcp/client.py
@@ -165,13 +165,15 @@ class MCPBrowserClient:
                 "evaluate_script",
                 {
                     "function": """(selector) => {
-                        const el = document.querySelector(selector);
-                        return el ? {exists: true} : null;
+                        return document.querySelector(selector) !== null;
                     }""",
                     "args": [selector],
                 },
             )
-            return {"exists": True} if result and result[0].text != "null" else None
+            # Check if the result indicates the element exists
+            if result and len(result) > 0 and result[0].text == "true":
+                return {"exists": True}
+            return None
         except Exception as e:
             logger.debug(f"Selector {selector} not found: {e}")
             return None


### PR DESCRIPTION
The query_selector method was returning a JavaScript object that wasn't being reliably serialized by the MCP protocol. Changed to return a boolean value which is more reliably serialized as "true"/"false" strings.

- Changed JavaScript to return boolean: document.querySelector(selector) !== null
- Updated Python check to compare against "true" string
- Added length check for robustness

Fixes the "Could not find search box" error in search audit.