### PR TITLE
Add support for OpenRouter LLM provider

### DIFF
--- a/configs/sites/nike.yaml
+++ b/configs/sites/nike.yaml
@@ -68,7 +68,7 @@ run:
 
 llm:
   provider: "openrouter"
-  model: "openai/gpt-4o-mini"
+  model: "qwen/qwen3-vl-30b-a3b-instruct"
   max_tokens: 1000
   temperature: 0.2
   system_prompt: null

--- a/configs/sites/nike.yaml
+++ b/configs/sites/nike.yaml
@@ -67,11 +67,13 @@ run:
   seed: 42
 
 llm:
-  provider: "openai"
-  model: "gpt-4o-mini"
+  provider: "openrouter"
+  model: "openai/gpt-4o-mini"
   max_tokens: 1000
   temperature: 0.2
   system_prompt: null
+  base_url: "https://openrouter.ai/api/v1"
+  api_key: null  # Set in .env as OPENROUTER_API_KEY
 
 report:
   formats:

--- a/src/agentic_search_audit/judge/judge.py
+++ b/src/agentic_search_audit/judge/judge.py
@@ -34,6 +34,16 @@ class SearchQualityJudge:
             if not api_key:
                 raise ValueError("OPENAI_API_KEY environment variable not set")
             self.client = AsyncOpenAI(api_key=api_key)
+        elif config.provider == "openrouter":
+            # OpenRouter uses OpenAI-compatible API
+            api_key = config.api_key or os.getenv("OPENROUTER_API_KEY")
+            if not api_key:
+                raise ValueError("OPENROUTER_API_KEY environment variable not set and no api_key in config")
+            base_url = config.base_url or "https://openrouter.ai/api/v1"
+            self.client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=base_url,
+            )
         else:
             raise ValueError(f"Unsupported LLM provider: {config.provider}")
 
@@ -129,7 +139,7 @@ class SearchQualityJudge:
         """
         logger.debug("Calling LLM for evaluation...")
 
-        if self.config.provider == "openai":
+        if self.config.provider in ["openai", "openrouter"]:
             response = await self.client.chat.completions.create(
                 model=self.config.model,
                 messages=[

--- a/src/agentic_search_audit/judge/judge.py
+++ b/src/agentic_search_audit/judge/judge.py
@@ -38,7 +38,9 @@ class SearchQualityJudge:
             # OpenRouter uses OpenAI-compatible API
             api_key = config.api_key or os.getenv("OPENROUTER_API_KEY")
             if not api_key:
-                raise ValueError("OPENROUTER_API_KEY environment variable not set and no api_key in config")
+                raise ValueError(
+                    "OPENROUTER_API_KEY environment variable not set and no api_key in config"
+                )
             base_url = config.base_url or "https://openrouter.ai/api/v1"
             self.client = AsyncOpenAI(
                 api_key=api_key,


### PR DESCRIPTION
- Add OpenRouter client initialization in judge.py
- Update _call_llm method to support OpenRouter
- Configure nike.yaml to use OpenRouter with gpt-4o-mini
- OpenRouter API key should be set via OPENROUTER_API_KEY env variable

Fixes: Unsupported LLM provider: openrouter error