### PR TITLE
Investigate cookies warning blocking search box

### DIFF
--- a/src/agentic_search_audit/core/orchestrator.py
+++ b/src/agentic_search_audit/core/orchestrator.py
@@ -109,6 +109,10 @@ class SearchAuditOrchestrator:
         Returns:
             AuditRecord with results and evaluation
         """
+        # Dismiss any modals that might be blocking the search box
+        modal_handler = ModalHandler(self.client, self.config.site.modals)
+        await modal_handler.dismiss_modals()
+
         # Find and submit search
         search_finder = SearchBoxFinder(
             self.client,


### PR DESCRIPTION
Added modal dismissal before each query is processed to ensure cookie consent banners and other modals don't block access to the search box. Previously, modals were only dismissed once during initial navigation, but they could reappear or be delayed, preventing search box interaction.

Now each query processing starts by dismissing any visible modals, ensuring reliable search box detection and interaction.